### PR TITLE
fix shell adapters bug that returns wrong number #34

### DIFF
--- a/bin/webby.js
+++ b/bin/webby.js
@@ -9,6 +9,7 @@ var robot = Webby.loadBot(null, 'shell', true, 'Webby', false);
 var loadScripts = function() {
   var scriptsPath = Path.resolve('.', 'scripts');
   robot.load(scriptsPath);
+
   scriptsPath = Path.resolve('.', 'src', 'scripts');
   robot.load(scriptsPath);
 

--- a/src/adapters/shell.js
+++ b/src/adapters/shell.js
@@ -18,19 +18,15 @@ console.log('shell adapter loaded');
 
 class Shell extends Adapter {
   send(envelope, ...strings) {
-    for (let str in strings) {
-      if (strings.hasOwnProperty(str)) {
-        console.log(chalk.bold(str));
-      }
-    }
+    strings.forEach(function(str) {
+      console.log(chalk.bold(str));
+    });
   }
 
   emote(envelope, ...strings) {
-    for (let str in strings) {
-      if (strings.hasOwnProperty(str)) {
-        this.send(envelope, '* ' + str);
-      }
-    }
+    strings.forEach(function(str) {
+      this.send(envelope, '* ' + str);
+    });
   }
 
   reply(envelope, ...strings) {

--- a/src/robot.js
+++ b/src/robot.js
@@ -362,8 +362,8 @@ class Robot {
     let anyListenersExecuted = false;
     async.detectSeries(this.listeners, (listener, cb) => {
       try {
-        listener.call(context.response.message,
-          this.middleware.listener, function(listenerExecuted) {
+        listener.call(context.response.message, this.middleware.listener,
+          function(listenerExecuted) {
             anyListenersExecuted = anyListenersExecuted || listenerExecuted;
             Middleware.ticker(function() {
               cb(context.response.message.done);


### PR DESCRIPTION
The issue is caused by the `hasOwnProperty` check inside of `for...in` loop

@raylin could you help review it?
